### PR TITLE
Investigate recovery slot interaction failure

### DIFF
--- a/slot.py
+++ b/slot.py
@@ -179,12 +179,6 @@ async def self_destruct_message(message, countdown_time=10):
                 discord.Color.orange()
             ))
 
-class RecoveryView(discord.ui.View):
-    @discord.ui.button(label="Recover Slot", style=discord.ButtonStyle.success, custom_id="recover_slot_btn")
-    async def recover_button(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await interaction.response.send_modal(RecoveryModal())
-
-
 
 def ping_usage_embed(everyone_used, here_used, plan, custom_limits=None):
     limits = custom_limits if custom_limits else PING_LIMITS[plan]
@@ -500,7 +494,7 @@ async def sendrecoverypanel(ctx):
         color=discord.Color.green()
     )
     embed.set_footer(text="Elite Key System • Recovery Panel")
-    await ctx.send(embed=embed, view=RecoveryView())
+    await ctx.send(embed=embed, view=PersistentRecoveryView())
 
 
 


### PR DESCRIPTION
Fix 'interaction failed' error on recovery panel by using `PersistentRecoveryView`.

The `RecoveryView` class used a default Discord.py UI view timeout of 180 seconds (3 minutes), causing interactions to fail after this period. Switching to `PersistentRecoveryView` (which has `timeout=None`) ensures the recovery buttons remain active indefinitely. The unused `RecoveryView` class was also removed for cleanup.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f4f93f8-dd25-4deb-a6b0-5c5a001cc79f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f4f93f8-dd25-4deb-a6b0-5c5a001cc79f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>